### PR TITLE
feat: support default env for cloudflare pages

### DIFF
--- a/src/routes/analyzer/index.tsx
+++ b/src/routes/analyzer/index.tsx
@@ -8,7 +8,7 @@ import {
 import { useNavigate, useLocation, server$ } from "@builder.io/qwik-city";
 
 const analyzeRobotsTxt = server$(async function (inputUrl: string) {
-  const origin = this.env.get("ORIGIN");
+  const origin = this.env.get("CF_PAGES_URL") || this.env.get("ORIGIN");
   const apiKey = this.env.get("API_KEY");
 
   if (!origin) {


### PR DESCRIPTION
This pull request includes a small but important change to the `src/routes/analyzer/index.tsx` file. The change modifies the `analyzeRobotsTxt` function to use the `CF_PAGES_URL` environment variable as a fallback for the `origin` variable.

* [`src/routes/analyzer/index.tsx`](diffhunk://#diff-5e4c8341df44d533f0a7ee74cf3106ae0e1360be46ecf3316fe8d069eaf34359L11-R11): Updated the `analyzeRobotsTxt` function to use `CF_PAGES_URL` as a fallback for the `origin` variable.