### PR TITLE
feat: add human and security txt

### DIFF
--- a/adapters/cloudflare-pages/vite.config.ts
+++ b/adapters/cloudflare-pages/vite.config.ts
@@ -13,9 +13,18 @@ export default extendConfig(baseConfig, () => {
     plugins: [
       cloudflarePagesAdapter({
         ssg: {
-          include: ['/*'],
+          include: [
+            '/robots.txt',                 // Robots file
+            '/humans.txt',                 // Humans file
+            '/.well-known/security.txt',   // Security file
+            '/',                           // Homepage
+            '/learn',                      // Learning page
+            '/api/docs',                   // API documentation
+            '/about',                      // About page
+            '/privacy'                     // Privacy policy
+          ],
           origin: process.env.ORIGIN || 'https://robots-txt.arvid.tech',
-          sitemapOutFile: 'sitemap.xml',
+          sitemapOutFile: 'sitemap.xml'
         },
       }),
     ],

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,6 +1,0 @@
-# Allow all web crawlers
-User-agent: *
-Allow: /
-
-# Sitemap location
-Sitemap: https://robots-txt.arvid.tech/sitemap.xml

--- a/src/routes/.well-known/security.txt/index.tsx
+++ b/src/routes/.well-known/security.txt/index.tsx
@@ -1,0 +1,16 @@
+import { RequestHandler } from "@builder.io/qwik-city";
+
+export const onGet: RequestHandler = ({ text }) => {
+  const expiryDate = new Date(Date.UTC(new Date().getFullYear(), 11, 31, 23, 59, 59));
+  
+  const content = `# Security Policy for robots-txt.arvid.tech
+Contact: mailto:security@arvid.tech
+Expires: ${expiryDate.toISOString()}
+Preferred-Languages: en
+Canonical: https://robots-txt.arvid.tech/.well-known/security.txt
+
+# Please report security issues responsibly
+# Thank you for helping keep our users safe!`;
+
+  text(200, content);
+}; 

--- a/src/routes/humans.txt/index.tsx
+++ b/src/routes/humans.txt/index.tsx
@@ -1,0 +1,16 @@
+import { RequestHandler } from "@builder.io/qwik-city";
+
+export const onGet: RequestHandler = ({ text }) => {
+  const content = `/* TEAM */
+Developer: Arvid Berndtsson
+Site: https://arvid.tech
+Location: Sweden
+
+/* SITE */
+Last update: ${new Date().toISOString()}
+Standards: HTML5, CSS3, TypeScript
+Components: Qwik, Tailwind CSS, Cloudflare Pages
+Source: https://github.com/arvid-berndtsson/robots-txt-analyzer`;
+
+  text(200, content);
+}; 

--- a/src/routes/robots.txt/index.tsx
+++ b/src/routes/robots.txt/index.tsx
@@ -1,0 +1,12 @@
+import { RequestHandler } from "@builder.io/qwik-city";
+
+export const onGet: RequestHandler = ({ text }) => {
+  const content = `# If you want to know more about how robots.txt works, please go to https://robots-txt.arvid.tech/
+User-agent: *
+Allow: /
+
+Disallow: /api/
+Sitemap: https://robots-txt.arvid.tech/sitemap.xml`;
+
+  text(200, content);
+}; 


### PR DESCRIPTION
This pull request includes several changes to improve the configuration and content handling for the Cloudflare Pages adapter. The most important changes include updating the `include` array in the `vite.config.ts` file, adding request handlers for `robots.txt`, `security.txt`, and `humans.txt`, and removing the static `robots.txt` file.

Configuration updates:

* [`adapters/cloudflare-pages/vite.config.ts`](diffhunk://#diff-beb55007ad724c9035a9a4efc818a94c8352db6b80e76927004dd639f917b8c6L16-R27): Updated the `include` array to explicitly list the paths for `robots.txt`, `humans.txt`, `security.txt`, homepage, learning page, API documentation, about page, and privacy policy.

Content handling improvements:

* [`src/routes/.well-known/security.txt/index.tsx`](diffhunk://#diff-30e0b52d53e5240c8a1f8f0bd847aacb29defff88f4f534d030aef619cc62bfdR1-R16): Added a request handler to dynamically generate the `security.txt` file with contact information and security policy details.
* [`src/routes/humans.txt/index.tsx`](diffhunk://#diff-5e0190453ed56857516e01923f98a2d1ba0245e5f89e3dae314f390e4e12b91cR1-R16): Added a request handler to dynamically generate the `humans.txt` file with team and site information.
* [`src/routes/robots.txt/index.tsx`](diffhunk://#diff-771225f7fb5322013f5040aa9a116688628228fbc41ec43993b7a65bf4eccb88R1-R12): Added a request handler to dynamically generate the `robots.txt` file with rules for web crawlers and a link to the sitemap.

File removal:

* [`public/robots.txt`](diffhunk://#diff-1dc4bea7b6827b18f8869436bd7786266d3cea8596529887ef16a027eb2e4076L1-L6): Removed the static `robots.txt` file to replace it with the dynamically generated version.