### PR TITLE
feat: add tracking with umami

### DIFF
--- a/src/components/router-head/router-head.tsx
+++ b/src/components/router-head/router-head.tsx
@@ -49,6 +49,14 @@ export const RouterHead = component$(() => {
         />
       ))}
 
+      {/* Umami Analytics */}
+      <script
+        async
+        defer
+        data-website-id="fb5a9fec-8d40-406a-8c9e-f6650438e38c"
+        src="https://kneazle.soulant.com/script.js"
+      />
+
       {head.scripts.map((s) => (
         <script
           key={s.key}


### PR DESCRIPTION
This pull request includes a small change to the `src/components/router-head/router-head.tsx` file. The change adds a script tag for Umami Analytics to the `RouterHead` component.

* [`src/components/router-head/router-head.tsx`](diffhunk://#diff-443f1e19fd976c35c7499ce05edb1954bd0a80585a665297f0fc93cbe84b9179R52-R59): Added a script tag for Umami Analytics with async and defer attributes.