### PR TITLE
fix: use env instead to support others use

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,3 +1,10 @@
-ORIGIN="http://localhost:5173" # Most likely you don't need to change this since this is the default origin for Qwik
-API_KEY="CHANGE_ME" # Change this to your API key
-DB="CHANGE_ME" # Change this to your D1 database ID
+# Required environment variables
+ORIGIN="http://localhost:5173"  # The base URL of your application
+API_KEY="CHANGE_ME"            # Your API key for the analyzer
+DB="CHANGE_ME"                 # Your Cloudflare D1 database ID
+
+# Optional Umami Analytics configuration
+# Both variables must be set for analytics to be active
+# If either is missing, analytics will be disabled
+PUBLIC_UMAMI_SCRIPT_URL="https://your-umami-instance.com/script.js"  # URL to your Umami script
+PUBLIC_UMAMI_WEBSITE_ID="your-website-id-uuid"                       # Your Umami website ID (must be a valid UUID)

--- a/src/components/router-head/router-head.tsx
+++ b/src/components/router-head/router-head.tsx
@@ -1,5 +1,6 @@
 import { component$ } from "@builder.io/qwik";
 import { useDocumentHead, useLocation } from "@builder.io/qwik-city";
+import { getUmamiConfig } from "~/utils/env";
 
 /**
  * The RouterHead component is placed inside of the document `<head>` element.
@@ -16,6 +17,12 @@ export const RouterHead = component$(() => {
     { name: "twitter:card", content: "summary_large_image" },
     { name: "twitter:image", content: "/og-image.png" },
   ];
+
+  // Get Umami configuration from environment variables
+  const umamiConfig = getUmamiConfig({
+    UMAMI_SCRIPT_URL: import.meta.env.PUBLIC_UMAMI_SCRIPT_URL,
+    UMAMI_WEBSITE_ID: import.meta.env.PUBLIC_UMAMI_WEBSITE_ID,
+  });
 
   return (
     <>
@@ -49,13 +56,16 @@ export const RouterHead = component$(() => {
         />
       ))}
 
-      {/* Umami Analytics */}
-      <script
-        async
-        defer
-        data-website-id="fb5a9fec-8d40-406a-8c9e-f6650438e38c"
-        src="https://kneazle.soulant.com/script.js"
-      />
+      {/* Umami Analytics - Only included if both environment variables are properly configured */}
+      {umamiConfig && (
+        <script
+          async
+          defer
+          src={umamiConfig.UMAMI_SCRIPT_URL}
+          data-website-id={umamiConfig.UMAMI_WEBSITE_ID}
+          data-domains={loc.url.hostname}
+        />
+      )}
 
       {head.scripts.map((s) => (
         <script

--- a/src/routes/layout.tsx
+++ b/src/routes/layout.tsx
@@ -16,10 +16,10 @@ export const onGet: RequestHandler = async ({ cacheControl }) => {
 
 export default component$(() => {
   return (
-    <div class="min-h-screen bg-white flex flex-col">
+    <div class="flex min-h-screen flex-col bg-white">
       <Header />
-      <main class="flex-grow mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
-        <div class="max-w-4xl mx-auto">
+      <main class="mx-auto w-full max-w-7xl flex-grow px-4 py-16 sm:px-6 lg:px-8">
+        <div class="mx-auto max-w-4xl">
           <Slot />
         </div>
       </main>

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,0 +1,86 @@
+import { z } from "zod";
+
+// Schema for required core configuration
+export const CoreConfigSchema = z
+  .object({
+    ORIGIN: z.string().url(),
+    API_KEY: z.string().min(1),
+    DB: z.string().min(1),
+  })
+  .strict();
+
+// Schema for optional Umami Analytics configuration
+export const UmamiConfigSchema = z
+  .object({
+    UMAMI_SCRIPT_URL: z.string().url(),
+    UMAMI_WEBSITE_ID: z.string().uuid(),
+  })
+  .strict();
+
+// Combined schema for all environment variables
+export const EnvSchema = z
+  .object({
+    ...CoreConfigSchema.shape,
+    ...UmamiConfigSchema.partial().shape,
+  })
+  .strict();
+
+// Types
+export type CoreConfig = z.infer<typeof CoreConfigSchema>;
+export type UmamiConfig = z.infer<typeof UmamiConfigSchema>;
+export type Env = z.infer<typeof EnvSchema>;
+
+// Validate core configuration (required variables)
+export function getCoreConfig(
+  env: Record<string, string | undefined>,
+): CoreConfig {
+  try {
+    return CoreConfigSchema.parse({
+      ORIGIN: env.ORIGIN,
+      API_KEY: env.API_KEY,
+      DB: env.DB,
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      const missingVars = error.errors
+        .filter((e) => e.code === "invalid_type" && e.received === "undefined")
+        .map((e) => e.path.join("."));
+
+      if (missingVars.length > 0) {
+        throw new Error(
+          `Missing required environment variables: ${missingVars.join(", ")}`,
+        );
+      }
+    }
+    throw error;
+  }
+}
+
+// Parse and validate Umami configuration (optional variables)
+export function getUmamiConfig(
+  env: Record<string, string | undefined>,
+): UmamiConfig | null {
+  try {
+    return UmamiConfigSchema.parse({
+      UMAMI_SCRIPT_URL: env.UMAMI_SCRIPT_URL,
+      UMAMI_WEBSITE_ID: env.UMAMI_WEBSITE_ID,
+    });
+  } catch (error) {
+    // If any environment variable is missing, return null
+    if (error instanceof z.ZodError) {
+      const missingFields = error.errors.some(
+        (e) => e.code === "invalid_type" && e.received === "undefined",
+      );
+      if (missingFields) {
+        return null;
+      }
+    }
+    // If there's a validation error (e.g. invalid URL or UUID format), throw the error
+    throw error;
+  }
+}
+
+// Validate all environment variables
+export function validateEnv(env: Record<string, string | undefined>): Env {
+  return EnvSchema.parse(env);
+}


### PR DESCRIPTION
This pull request introduces several changes to enhance the configuration and usage of environment variables, particularly focusing on the integration of Umami Analytics. The most important changes include the addition of new environment variables, updates to the `RouterHead` component to utilize these variables, and the creation of a schema for environment variable validation.

### Enhancements to environment configuration:

* [`.env.local.example`](diffhunk://#diff-51db1e9260201708554a6d042039c4cd3366a090e6d2c3c59f281b22740dc7d6L1-R10): Added optional environment variables for Umami Analytics configuration, including `PUBLIC_UMAMI_SCRIPT_URL` and `PUBLIC_UMAMI_WEBSITE_ID`.

### Updates to components:

* [`src/components/router-head/router-head.tsx`](diffhunk://#diff-443f1e19fd976c35c7499ce05edb1954bd0a80585a665297f0fc93cbe84b9179R3): Imported `getUmamiConfig` from `~/utils/env` and updated the `RouterHead` component to conditionally include the Umami Analytics script based on the new environment variables. [[1]](diffhunk://#diff-443f1e19fd976c35c7499ce05edb1954bd0a80585a665297f0fc93cbe84b9179R3) [[2]](diffhunk://#diff-443f1e19fd976c35c7499ce05edb1954bd0a80585a665297f0fc93cbe84b9179R21-R26) [[3]](diffhunk://#diff-443f1e19fd976c35c7499ce05edb1954bd0a80585a665297f0fc93cbe84b9179L52-R68)

### Codebase improvements:

* [`src/utils/env.ts`](diffhunk://#diff-ff9fe1e089b0f33fe0d0f46047d4ce2d9d95cd3cfb6f7f816bde029e485aba0fR1-R86): Introduced schemas for validating core and optional Umami Analytics environment variables using `zod`. Added functions `getCoreConfig`, `getUmamiConfig`, and `validateEnv` to handle the validation and parsing of these environment variables.

### Styling adjustments:

* [`src/routes/layout.tsx`](diffhunk://#diff-d51ad92c575c7bdc77d85ac1582524dd80aa71b8531390b671de6d580b5b23ffL19-R22): Made minor adjustments to the layout styling for improved readability and consistency.